### PR TITLE
Improve student activity registration system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+pytest
+httpx

--- a/src/app.py
+++ b/src/app.py
@@ -105,3 +105,22 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/unregister")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    # Validate activity exists
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    # Get the specific activity
+    activity = activities[activity_name]
+
+    # Validate student is signed up
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student is not registered for this activity")
+
+    # Remove student
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Basketball Team": {
+        "description": "Join the school basketball team and compete in tournaments",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 6:00 PM",
+        "max_participants": 15,
+        "participants": ["james@mergington.edu"]
+    },
+    "Swimming Club": {
+        "description": "Improve swimming techniques and participate in competitions",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": ["sarah@mergington.edu", "alex@mergington.edu"]
+    },
+    "Art Club": {
+        "description": "Explore various art mediums including painting, drawing, and sculpture",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["lily@mergington.edu"]
+    },
+    "Drama Theater": {
+        "description": "Perform in school plays and learn acting techniques",
+        "schedule": "Tuesdays and Fridays, 3:30 PM - 5:30 PM",
+        "max_participants": 20,
+        "participants": ["emily@mergington.edu", "noah@mergington.edu"]
+    },
+    "Debate Team": {
+        "description": "Develop critical thinking and public speaking skills through debates",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 16,
+        "participants": ["william@mergington.edu"]
+    },
+    "Science Olympiad": {
+        "description": "Compete in science and engineering competitions",
+        "schedule": "Mondays and Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 18,
+        "participants": ["ava@mergington.edu", "ethan@mergington.edu"]
     }
 }
 
@@ -61,6 +97,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
 
     # Add student
     activity["participants"].append(email)

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -20,11 +20,21 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const spotsLeft = details.max_participants - details.participants.length;
 
+        const participantsList = details.participants.length > 0
+          ? `<ul class="participants-list">
+              ${details.participants.map(email => `<li>${email}</li>`).join('')}
+            </ul>`
+          : '<p class="no-participants">No participants yet</p>';
+
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <strong>Participants:</strong>
+            ${participantsList}
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -4,6 +4,50 @@ document.addEventListener("DOMContentLoaded", () => {
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
 
+  // Function to handle unregistering a participant
+  async function handleUnregister(event) {
+    const activityName = event.target.dataset.activity;
+    const email = event.target.dataset.email;
+
+    if (!confirm(`Are you sure you want to unregister ${email} from ${activityName}?`)) {
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activityName)}/unregister?email=${encodeURIComponent(email)}`,
+        {
+          method: "DELETE",
+        }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        // Refresh the activities list
+        await fetchActivities();
+        
+        messageDiv.textContent = result.message;
+        messageDiv.className = "success";
+      } else {
+        messageDiv.textContent = result.detail || "An error occurred";
+        messageDiv.className = "error";
+      }
+
+      messageDiv.classList.remove("hidden");
+
+      // Hide message after 5 seconds
+      setTimeout(() => {
+        messageDiv.classList.add("hidden");
+      }, 5000);
+    } catch (error) {
+      messageDiv.textContent = "Failed to unregister. Please try again.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      console.error("Error unregistering:", error);
+    }
+  }
+
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
@@ -22,7 +66,12 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const participantsList = details.participants.length > 0
           ? `<ul class="participants-list">
-              ${details.participants.map(email => `<li>${email}</li>`).join('')}
+              ${details.participants.map(email => `
+                <li>
+                  <span>${email}</span>
+                  <span class="delete-icon" data-activity="${name}" data-email="${email}" title="Unregister">✕</span>
+                </li>
+              `).join('')}
             </ul>`
           : '<p class="no-participants">No participants yet</p>';
 
@@ -44,6 +93,11 @@ document.addEventListener("DOMContentLoaded", () => {
         option.value = name;
         option.textContent = name;
         activitySelect.appendChild(option);
+      });
+
+      // Add event listeners for delete icons
+      document.querySelectorAll('.delete-icon').forEach(icon => {
+        icon.addEventListener('click', handleUnregister);
       });
     } catch (error) {
       activitiesList.innerHTML = "<p>Failed to load activities. Please try again later.</p>";
@@ -69,6 +123,9 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
+        // Refresh the activities list
+        await fetchActivities();
+        
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -87,15 +87,38 @@ section h3 {
 }
 
 .participants-list {
-  list-style-type: disc;
-  padding-left: 25px;
+  list-style-type: none;
+  padding-left: 0;
   margin: 0;
 }
 
 .participants-list li {
-  padding: 3px 0;
+  padding: 8px 0;
   color: #555;
   font-size: 14px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.participants-list li:last-child {
+  border-bottom: none;
+}
+
+.delete-icon {
+  cursor: pointer;
+  color: #d32f2f;
+  font-size: 18px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  transition: background-color 0.2s, color 0.2s;
+  user-select: none;
+}
+
+.delete-icon:hover {
+  background-color: #ffebee;
+  color: #c62828;
 }
 
 .no-participants {

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,37 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 15px;
+  padding-top: 15px;
+  border-top: 1px solid #e0e0e0;
+}
+
+.participants-section strong {
+  display: block;
+  margin-bottom: 8px;
+  color: #1a237e;
+}
+
+.participants-list {
+  list-style-type: disc;
+  padding-left: 25px;
+  margin: 0;
+}
+
+.participants-list li {
+  padding: 3px 0;
+  color: #555;
+  font-size: 14px;
+}
+
+.no-participants {
+  font-style: italic;
+  color: #999;
+  margin: 0;
+  font-size: 14px;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests package

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,243 @@
+"""
+Test suite for the Mergington High School API
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from src.app import app, activities
+
+
+@pytest.fixture
+def client():
+    """Create a test client for the FastAPI app"""
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_activities():
+    """Reset activities data before each test"""
+    # Store original state
+    original_activities = {
+        name: {
+            "description": details["description"],
+            "schedule": details["schedule"],
+            "max_participants": details["max_participants"],
+            "participants": details["participants"].copy()
+        }
+        for name, details in activities.items()
+    }
+    
+    yield
+    
+    # Restore original state after test
+    for name, details in original_activities.items():
+        if name in activities:
+            activities[name]["participants"] = details["participants"].copy()
+
+
+class TestRootEndpoint:
+    """Tests for the root endpoint"""
+    
+    def test_root_redirects_to_static(self, client):
+        """Test that root endpoint redirects to static index.html"""
+        response = client.get("/", follow_redirects=False)
+        assert response.status_code == 307
+        assert response.headers["location"] == "/static/index.html"
+
+
+class TestGetActivities:
+    """Tests for GET /activities endpoint"""
+    
+    def test_get_activities_returns_all_activities(self, client):
+        """Test that GET /activities returns all activities"""
+        response = client.get("/activities")
+        assert response.status_code == 200
+        data = response.json()
+        
+        assert isinstance(data, dict)
+        assert "Chess Club" in data
+        assert "Programming Class" in data
+        assert "Gym Class" in data
+        
+    def test_activities_have_required_fields(self, client):
+        """Test that each activity has required fields"""
+        response = client.get("/activities")
+        data = response.json()
+        
+        for activity_name, activity_details in data.items():
+            assert "description" in activity_details
+            assert "schedule" in activity_details
+            assert "max_participants" in activity_details
+            assert "participants" in activity_details
+            assert isinstance(activity_details["participants"], list)
+
+
+class TestSignupForActivity:
+    """Tests for POST /activities/{activity_name}/signup endpoint"""
+    
+    def test_signup_success(self, client):
+        """Test successful signup for an activity"""
+        response = client.post(
+            "/activities/Chess%20Club/signup?email=test@mergington.edu"
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "message" in data
+        assert "test@mergington.edu" in data["message"]
+        
+        # Verify participant was added
+        activities_response = client.get("/activities")
+        activities_data = activities_response.json()
+        assert "test@mergington.edu" in activities_data["Chess Club"]["participants"]
+    
+    def test_signup_for_nonexistent_activity(self, client):
+        """Test signup for an activity that doesn't exist"""
+        response = client.post(
+            "/activities/Nonexistent%20Activity/signup?email=test@mergington.edu"
+        )
+        assert response.status_code == 404
+        data = response.json()
+        assert "detail" in data
+        assert "not found" in data["detail"].lower()
+    
+    def test_signup_duplicate_participant(self, client):
+        """Test that duplicate signup is rejected"""
+        email = "duplicate@mergington.edu"
+        
+        # First signup should succeed
+        response1 = client.post(
+            f"/activities/Chess%20Club/signup?email={email}"
+        )
+        assert response1.status_code == 200
+        
+        # Second signup should fail
+        response2 = client.post(
+            f"/activities/Chess%20Club/signup?email={email}"
+        )
+        assert response2.status_code == 400
+        data = response2.json()
+        assert "already signed up" in data["detail"].lower()
+
+
+class TestUnregisterFromActivity:
+    """Tests for DELETE /activities/{activity_name}/unregister endpoint"""
+    
+    def test_unregister_success(self, client):
+        """Test successful unregistration from an activity"""
+        # First, sign up a participant
+        email = "unregister@mergington.edu"
+        client.post(f"/activities/Chess%20Club/signup?email={email}")
+        
+        # Then unregister
+        response = client.delete(
+            f"/activities/Chess%20Club/unregister?email={email}"
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "message" in data
+        assert email in data["message"]
+        
+        # Verify participant was removed
+        activities_response = client.get("/activities")
+        activities_data = activities_response.json()
+        assert email not in activities_data["Chess Club"]["participants"]
+    
+    def test_unregister_from_nonexistent_activity(self, client):
+        """Test unregister from an activity that doesn't exist"""
+        response = client.delete(
+            "/activities/Nonexistent%20Activity/unregister?email=test@mergington.edu"
+        )
+        assert response.status_code == 404
+        data = response.json()
+        assert "detail" in data
+        assert "not found" in data["detail"].lower()
+    
+    def test_unregister_not_registered_participant(self, client):
+        """Test unregistering a participant who is not registered"""
+        response = client.delete(
+            "/activities/Chess%20Club/unregister?email=notregistered@mergington.edu"
+        )
+        assert response.status_code == 400
+        data = response.json()
+        assert "not registered" in data["detail"].lower()
+    
+    def test_unregister_existing_participant(self, client):
+        """Test unregistering an existing participant"""
+        # Use a participant that exists in the initial data
+        email = "michael@mergington.edu"
+        
+        response = client.delete(
+            f"/activities/Chess%20Club/unregister?email={email}"
+        )
+        assert response.status_code == 200
+        
+        # Verify participant was removed
+        activities_response = client.get("/activities")
+        activities_data = activities_response.json()
+        assert email not in activities_data["Chess Club"]["participants"]
+
+
+class TestActivityCapacity:
+    """Tests for activity capacity constraints"""
+    
+    def test_activity_max_participants_respected(self, client):
+        """Test that activities track participants correctly"""
+        # Get initial participant count
+        response = client.get("/activities")
+        data = response.json()
+        initial_count = len(data["Chess Club"]["participants"])
+        max_participants = data["Chess Club"]["max_participants"]
+        
+        # Calculate how many more participants can be added
+        spots_available = max_participants - initial_count
+        
+        # Add participants up to the maximum
+        for i in range(spots_available):
+            email = f"student{i}@mergington.edu"
+            response = client.post(
+                f"/activities/Chess%20Club/signup?email={email}"
+            )
+            assert response.status_code == 200
+        
+        # Verify all participants were added
+        response = client.get("/activities")
+        data = response.json()
+        assert len(data["Chess Club"]["participants"]) == max_participants
+
+
+class TestIntegrationScenarios:
+    """Integration tests for common user scenarios"""
+    
+    def test_signup_and_unregister_flow(self, client):
+        """Test the complete flow of signing up and then unregistering"""
+        email = "flowtest@mergington.edu"
+        activity = "Programming Class"
+        
+        # Step 1: Get initial state
+        response = client.get("/activities")
+        initial_data = response.json()
+        initial_participants = initial_data[activity]["participants"].copy()
+        
+        # Step 2: Sign up
+        response = client.post(
+            f"/activities/{activity.replace(' ', '%20')}/signup?email={email}"
+        )
+        assert response.status_code == 200
+        
+        # Step 3: Verify signup
+        response = client.get("/activities")
+        data = response.json()
+        assert email in data[activity]["participants"]
+        assert len(data[activity]["participants"]) == len(initial_participants) + 1
+        
+        # Step 4: Unregister
+        response = client.delete(
+            f"/activities/{activity.replace(' ', '%20')}/unregister?email={email}"
+        )
+        assert response.status_code == 200
+        
+        # Step 5: Verify unregistration
+        response = client.get("/activities")
+        data = response.json()
+        assert email not in data[activity]["participants"]
+        assert len(data[activity]["participants"]) == len(initial_participants)


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the Mergington High School activities app, focusing on participant management and user experience. The most significant changes include the ability for users to unregister from activities, improved frontend display and interaction for managing participants, expanded activity options, and the addition of a comprehensive test suite to ensure API reliability.

**Backend features and API improvements:**

* Added a new DELETE endpoint (`/activities/{activity_name}/unregister`) to allow students to unregister from activities, including validation for registration status and activity existence.
* Enhanced the signup logic to prevent duplicate registrations for the same activity.

**Frontend enhancements:**

* Displayed participants for each activity with a styled list and added an interactive "delete" icon next to each participant, enabling unregistering directly from the UI. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R67-R86) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R97-R101) [[3]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R77-R130)
* Implemented the `handleUnregister` JavaScript function to call the new backend unregister endpoint, update the UI, and provide user feedback.
* Ensured the activities list refreshes after signup or unregister actions for up-to-date participant information.

**Data and testing improvements:**

* Added several new activities (`Basketball Team`, `Swimming Club`, `Art Club`, `Drama Theater`, `Debate Team`, `Science Olympiad`) to the activities data model.
* Introduced a robust test suite for the API, covering endpoints, edge cases, and integration scenarios, with fixtures to reset state between tests. [[1]](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79R1-R243) [[2]](diffhunk://#diff-001e61d97d9dee27d0c5aa1f23ba6c1972cd8a2e8320bac839656b0ab935b84dR1)